### PR TITLE
fix: correct makefile to execute main

### DIFF
--- a/PARCIAL 1/Makefile
+++ b/PARCIAL 1/Makefile
@@ -76,6 +76,9 @@ $(OUTDIR)/$(SOURCE_DIR)/helpers: | $(OUTDIR)
 $(OUTDIR)/$(SOURCE_DIR)/core: | $(OUTDIR)
 	mkdir -p $(OUTDIR)/$(SOURCE_DIR)/core
 
+$(OUTDIR)/$(SOURCE_DIR): | $(OUTDIR)
+	mkdir -p $(OUTDIR)/$(SOURCE_DIR)
+
 
 # Clean output files
 clean:

--- a/PARCIAL 1/src/main.cpp
+++ b/PARCIAL 1/src/main.cpp
@@ -23,7 +23,7 @@ void printHelp(const char* programName) {
     std::cout << "  --encrypt, -e      Encrypt a message file using a public key\n";
     std::cout << "  --decrypt, -d      Decrypt a message file using a private key\n";
     std::cout << "\nExamples:\n";
-    std::cout << "  " << programName << " --generate\n";
+    std::cout << "  " << programName << " --generate keys/public_key.txt keys/private_key.txt\n";
     std::cout << "  " << programName << " --encrypt messages/original_message.txt keys/public_key.txt\n";
     std::cout << "  " << programName << " --decrypt messages/encrypted_message.txt keys/private_key.txt\n";
     std::cout << std::endl;
@@ -39,8 +39,16 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    int PRIME1 = std::stoi(std::getenv("PRIME1"));
-    int PRIME2 = std::stoi(std::getenv("PRIME2"));
+    const char* prime1_env = std::getenv("PRIME1");
+    const char* prime2_env = std::getenv("PRIME2");
+
+    if (!prime1_env || !prime2_env) {
+        std::cerr << "Error: Las variables de entorno PRIME1 y PRIME2 deben estar definidas." << std::endl;
+        return 1;
+    }
+
+    int PRIME1 = std::stoi(prime1_env);
+    int PRIME2 = std::stoi(prime2_env);
 
     Rsa rsa_management(PRIME1, PRIME2);
 
@@ -59,7 +67,7 @@ int main(int argc, char* argv[]) {
         const char* defaultPublicKeyPath;
         const char* defaultPrivateKeyPath;
 
-        if (argc<2){
+        if (argc<=2){
             defaultPublicKeyPath = "keys/public_key.txt";
             defaultPrivateKeyPath = "keys/private_key.txt";
         }


### PR DESCRIPTION
This pull request includes several changes to the `PARCIAL 1` project, focusing on improvements to the build process and enhancements to the main application logic for better error handling and user guidance. The most important changes include adding a new directory creation rule in the Makefile, updating the help message for the program, and improving environment variable handling in the main function.

Build process improvements:

* [`PARCIAL 1/Makefile`](diffhunk://#diff-a614361f0578e39458be63e538e8819580ac02ed3ac3140db4ec600934c88b48R79-R81): Added a new rule to create the `$(OUTDIR)/$(SOURCE_DIR)` directory if it does not exist.

Enhancements to main application logic:

* [`PARCIAL 1/src/main.cpp`](diffhunk://#diff-74d90ea98dcebab1251cfe23abeffde83c5b8948cb8eb8683b234d4d30f3d1b9L26-R26): Updated the help message to provide a more detailed example for the `--generate` command, specifying the paths for the public and private keys.
* [`PARCIAL 1/src/main.cpp`](diffhunk://#diff-74d90ea98dcebab1251cfe23abeffde83c5b8948cb8eb8683b234d4d30f3d1b9L42-R51): Improved error handling by checking if the environment variables `PRIME1` and `PRIME2` are defined before converting them to integers, and displaying an error message if they are not set.
* [`PARCIAL 1/src/main.cpp`](diffhunk://#diff-74d90ea98dcebab1251cfe23abeffde83c5b8948cb8eb8683b234d4d30f3d1b9L62-R70): Modified the argument check condition to correctly set default key paths when fewer than two arguments are provided.