### PR TITLE
Feat/add image scaling

### DIFF
--- a/PARCIAL 2/src/core/ImageManager.cpp
+++ b/PARCIAL 2/src/core/ImageManager.cpp
@@ -111,3 +111,47 @@ void ImageManager::rotateImage(float angleDegrees, Pixel fillColor, unsigned cha
     width = newWidth;
     height = newHeight;
 }
+
+void ImageManager::scaleImage(float scaleFactor, unsigned char** transformedPixels, unsigned char** originalPixels) {
+    /**
+     * Scale the image by the specified factor and store the result in the provided buffer.
+     * 
+     * @param scaleFactor The scaling factor to apply..
+     * @param transformedPixels The buffer to store the scaled image.
+     * @param originalPixels The original image buffer.
+     */
+    int newWidth = static_cast<int>(width * scaleFactor);
+    int newHeight = static_cast<int>(height * scaleFactor);
+
+    for (int yNew = 0; yNew < newHeight; ++yNew) {
+        for (int xNew = 0; xNew < newWidth; ++xNew) {
+
+            float xOrig = xNew / scaleFactor;
+            float yOrig = yNew / scaleFactor;
+
+            int x0 = static_cast<int>(std::floor(xOrig));
+            int y0 = static_cast<int>(std::floor(yOrig));
+            int x1 = std::min(x0 + 1, width - 1);
+            int y1 = std::min(y0 + 1, height - 1);
+
+            float dx = xOrig - x0;
+            float dy = yOrig - y0;
+
+            if (x1 < width && y1 < height) {
+                for (int c = 0; c < channels; ++c) {
+                    float pixel =
+                        (1 - dx) * (1 - dy) * originalPixels[y0][x0 * channels + c] +
+                        dx * (1 - dy) * originalPixels[y0][x1 * channels + c] +
+                        (1 - dx) * dy * originalPixels[y1][x0 * channels + c] +
+                        dx * dy * originalPixels[y1][x1 * channels + c];
+
+                    int idxDst = xNew * channels + c;
+                    transformedPixels[yNew][idxDst] = static_cast<unsigned char>(std::round(pixel));
+                }
+            }
+        }
+    }
+
+    width = newWidth;
+    height = newHeight;
+}

--- a/PARCIAL 2/src/core/ImageManager.h
+++ b/PARCIAL 2/src/core/ImageManager.h
@@ -13,7 +13,8 @@ public:
     ImageManager(int width, int height, int channels);
 
     void rotateImage(float angleDegrees, Pixel fillColor, unsigned char** transformedPixels, unsigned char** originalPixels, int newWidth, int newHeight);
-
+    void scaleImage(float scaleFactor, unsigned char** transformedPixels, unsigned char** originalPixels);
+        
     int getWidth() const;
     int getHeight() const;
     int getChannels() const;

--- a/PARCIAL 2/src/main.cpp
+++ b/PARCIAL 2/src/main.cpp
@@ -16,6 +16,8 @@ void showUsage() {
     cout << "  <factor>        Rotation angle in degrees" << endl;
     cout << "  -buddy          Use Buddy System for memory allocation" << endl;
     cout << "  -no-buddy       Use new/delete for memory allocation" << endl;
+    cout << "  -rotate         Rotate the image" << endl;
+    cout << "  -scale          Scale the image" << endl;
 }
 
 void showChecklist(const string &inputFile, const string &outputFile, bool useBuddy, double factor) {
@@ -28,7 +30,7 @@ void showChecklist(const string &inputFile, const string &outputFile, bool useBu
 }
 
 int main(int argc, char* argv[]) {
-    if (argc != 5) {
+    if (argc != 6) {
         cerr << "Error: Incorrect number of arguments." << endl;
         showUsage();
         return 1;
@@ -38,6 +40,7 @@ int main(int argc, char* argv[]) {
     string outputFile = argv[2];
     double factor = stod(argv[3]);
     string allocationMode = argv[4];
+    string operation = argv[5];
 
     bool useBuddy;
     if (allocationMode == "-buddy") {
@@ -53,8 +56,19 @@ int main(int argc, char* argv[]) {
     showChecklist(inputFile, outputFile, useBuddy, factor);
 
     auto start = high_resolution_clock::now();
+    TransformationMethod method;
+    if (operation == "-rotate") {
+        method = TransformationMethod::ROTATION;
+    } else if (operation == "-scale") {
+        method = TransformationMethod::SCALING;
+    } else {
+        cerr << "Error: Invalid operation (-rotate or -scale)." << endl;
+        showUsage();
+        return 1;
+    }
 
-    FileManager fm(inputFile, outputFile, TransformationMethod::ROTATION, useBuddy, factor);
+    FileManager fm(inputFile, outputFile, method, useBuddy, factor);
+
     unsigned char** originalPixels = fm.initializeOriginalPixelsFromFile();
     fm.showFileInfo();
 
@@ -62,15 +76,23 @@ int main(int argc, char* argv[]) {
     unsigned char** transformedPixels = fm.initializeTransformedPixels();
 
     Pixel fillColor = {0, 0, 0, 255};
-    imgManager.rotateImage(factor, fillColor, transformedPixels, originalPixels, fm.getTransformedImageWidth(), fm.getTransformedImageHeight());
-
+    if (operation == "-rotate") {
+        imgManager.rotateImage(factor, fillColor, transformedPixels, originalPixels, fm.getTransformedImageWidth(), fm.getTransformedImageHeight());
+    } else if (operation == "-scale") {
+        imgManager.scaleImage(factor, transformedPixels, originalPixels);
+    }
+    
     fm.saveImage(transformedPixels, fm.getTransformedImageWidth(), fm.getTransformedImageHeight(), fm.getChannels());
 
     auto end = high_resolution_clock::now();
     auto duration = duration_cast<milliseconds>(end - start).count();
 
     cout << "\nTotal processing time: " << duration << " ms" << endl;
-    cout << "\n[INFO] Rotated image successfully saved." << endl;
+    if (operation == "-rotate") {
+        cout << "\n[INFO] Rotated image successfully saved." << endl;
+    } else {
+        cout << "\n[INFO] Scaled image successfully saved." << endl;
+    }    
 
     return 0;
 }

--- a/PARCIAL 2/src/tests/testImageManager.cpp
+++ b/PARCIAL 2/src/tests/testImageManager.cpp
@@ -89,6 +89,35 @@ TEST_F(ImageManagerTest, RotateImageKeepsDimensions) {
     delete[] rotatedPixels;
 }
 
+TEST_F(ImageManagerTest, ScaleImageChangesDimensionsCorrectly) {
+    float scaleFactor = 2.0f;
+    int newWidth = static_cast<int>(width * scaleFactor);
+    int newHeight = static_cast<int>(height * scaleFactor);
+
+    unsigned char** scaledPixels = new unsigned char*[newHeight];
+    for (int y = 0; y < newHeight; y++) {
+        scaledPixels[y] = new unsigned char[newWidth * channels];
+    }
+
+    imgManager->scaleImage(scaleFactor, scaledPixels, originalPixels);
+
+    EXPECT_EQ(imgManager->getWidth(), newWidth);
+    EXPECT_EQ(imgManager->getHeight(), newHeight);
+
+    int cx = newWidth / 2;
+    int cy = newHeight / 2;
+    int idx = cx * channels;
+
+    EXPECT_GE(scaledPixels[cy][idx], 0);
+    EXPECT_LE(scaledPixels[cy][idx], 255);
+
+    for (int y = 0; y < newHeight; y++) {
+        delete[] scaledPixels[y];
+    }
+    delete[] scaledPixels;
+}
+
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
This pull request introduces a new feature to the `ImageManager` class for scaling images. It also updates the main application to support this new functionality and includes a corresponding test case.

### New Feature: Image Scaling

* [`PARCIAL 2/src/core/ImageManager.cpp`](diffhunk://#diff-268b05858704a57751c5ee5e0db81e63031c3e140f54bfc4adb7c6e18d4fc1bfR114-R157): Added the `scaleImage` method to the `ImageManager` class to scale images based on a given factor. This method calculates the new dimensions and applies bilinear interpolation to transform the image.
* [`PARCIAL 2/src/core/ImageManager.h`](diffhunk://#diff-138a080e962322bbb899a618700c9b3e27d786d797bf886da43c6328839bfe3dR16): Declared the new `scaleImage` method in the `ImageManager` class.

### Main Application Updates

* [`PARCIAL 2/src/main.cpp`](diffhunk://#diff-afe6f5a68e44461e825831d0f32e39a2b644e1faecab181f6708cab90e0c618aR19-R20): Updated the `showUsage` function to include the `-scale` option and modified the `main` function to handle the new `-scale` operation. This includes parsing the new argument, initializing the appropriate transformation method, and calling the new `scaleImage` method. [[1]](diffhunk://#diff-afe6f5a68e44461e825831d0f32e39a2b644e1faecab181f6708cab90e0c618aR19-R20) [[2]](diffhunk://#diff-afe6f5a68e44461e825831d0f32e39a2b644e1faecab181f6708cab90e0c618aL31-R33) [[3]](diffhunk://#diff-afe6f5a68e44461e825831d0f32e39a2b644e1faecab181f6708cab90e0c618aR43) [[4]](diffhunk://#diff-afe6f5a68e44461e825831d0f32e39a2b644e1faecab181f6708cab90e0c618aR59-R95)

### Testing

* [`PARCIAL 2/src/tests/testImageManager.cpp`](diffhunk://#diff-817fc1a417a487dd94662536562aa5e3cf6b45a126a5dfbde152a4e1ce00a13fR92-R120): Added a new test case `ScaleImageChangesDimensionsCorrectly` to verify that the `scaleImage` method correctly updates the image dimensions and scales the pixels appropriately.